### PR TITLE
Prevent parsing of CSS files

### DIFF
--- a/evaluator.js
+++ b/evaluator.js
@@ -93,6 +93,9 @@ class RequireCSSEvaluator extends Evaluator {
 
         // shortcut for empty files
         if (!str.trim()) return nodes.null;
+        
+        // Prevent Stylus from attempting to parse CSS urls
+        str = file.endsWith('.css') ? `@css { ${str} }` : str;
 
         // Expose imports
         node.path = file;


### PR DESCRIPTION
Stylus doesn't like data URIs that are not wrapped in quotes. This will prevent stylus from attempting to parse the CSS. https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs